### PR TITLE
feat: add sixel support for transparent images

### DIFF
--- a/textual_image/_sixel.py
+++ b/textual_image/_sixel.py
@@ -58,6 +58,7 @@ _QUANTIZE_METHODS: dict[QuantizeMethod, PILImage.Quantize] = {
 AnyBytes: TypeAlias = bytes | bytearray
 Segment: TypeAlias = tuple[int, int, int]  # (start_col, end_col, color)
 ColorSpans: TypeAlias = dict[int, tuple[int, int]]  # {color: (start_col, end_col)}
+BackgroundColor: TypeAlias = tuple[int, int, int, float]  # (R, G, B, alpha)
 
 
 @dataclass(frozen=True)
@@ -87,11 +88,16 @@ class SixelOptions:
     quantize: QuantizeMethod = "fastoctree"
 
 
-def image_to_sixels(image: PILImage.Image, options: SixelOptions | None = None) -> str:
+def image_to_sixels(
+    image: PILImage.Image,
+    options: SixelOptions | None = None,
+    background: BackgroundColor | None = None,
+) -> str:
     """Convert a PIL Image to a sixel-encoded string."""
     options = options or SixelOptions()
+    background = background or (0, 0, 0, 1.0)
 
-    image = _prepare_image(image, options)
+    image = _prepare_image(image, options, background)
     raw_data = image.tobytes()
 
     if _HAS_NUMPY:
@@ -105,8 +111,28 @@ def image_to_sixels(image: PILImage.Image, options: SixelOptions | None = None) 
     return (header + b"".join(chunks) + _ST).decode("ascii")
 
 
-def _prepare_image(image: PILImage.Image, options: SixelOptions) -> PILImage.Image:
+def _has_transparency(image: PILImage.Image) -> bool:
+    """Check if an image has an alpha channel or palette transparency."""
+    return image.mode in ("RGBA", "LA", "PA") or (image.mode == "P" and "transparency" in image.info)
+
+
+def _composite_on_background(image: PILImage.Image, background: BackgroundColor) -> PILImage.Image:
+    """Alpha-composite *image* onto *background*, returning an RGB image."""
+    rgba = image.convert("RGBA")
+    *bg_rgb, bg_alpha = background
+    bg = PILImage.new("RGBA", rgba.size, (*bg_rgb, int(bg_alpha * 255)))
+    return PILImage.alpha_composite(bg, rgba).convert("RGB")
+
+
+def _prepare_image(
+    image: PILImage.Image,
+    options: SixelOptions,
+    background: BackgroundColor,
+) -> PILImage.Image:
     """Convert any image to paletted mode, skipping requantization when possible."""
+    if _has_transparency(image):
+        image = _composite_on_background(image, background)
+
     n_colors = options.colors
     small_palette = len(set(image.tobytes())) <= n_colors
 

--- a/textual_image/widget/sixel.py
+++ b/textual_image/widget/sixel.py
@@ -18,7 +18,7 @@ from typing_extensions import override
 
 from textual_image._geometry import ImageSize
 from textual_image._pixeldata import PixelData
-from textual_image._sixel import SixelOptions, image_to_sixels
+from textual_image._sixel import BackgroundColor, SixelOptions, image_to_sixels
 from textual_image._terminal import CellSize, get_cell_size
 from textual_image._utils import StrOrBytesPath
 from textual_image.widget._base import Image as BaseImage
@@ -35,6 +35,7 @@ class _CachedSixels(NamedTuple):
     content_size: Size
     terminal_sizes: CellSize
     sixel_options: SixelOptions | None
+    background: BackgroundColor
     sixel_data: str
 
     def is_hit(
@@ -44,6 +45,7 @@ class _CachedSixels(NamedTuple):
         content_size: Size,
         terminal_sizes: CellSize,
         sixel_options: SixelOptions | None,
+        background: BackgroundColor,
     ) -> bool:
         return (
             image == self.image
@@ -51,6 +53,7 @@ class _CachedSixels(NamedTuple):
             and content_size == self.content_size
             and terminal_sizes == self.terminal_sizes
             and sixel_options == self.sixel_options
+            and background == self.background
         )
 
 
@@ -167,9 +170,10 @@ class _ImageSixelImpl(Widget, can_focus=False, inherit_css=False):
 
         # Inject the sixel data. We can only do it here because we don't know the crop region before.
         terminal_sizes = get_cell_size()
+        background = self._get_background_rgba()
 
         if self._cached_sixels and self._cached_sixels.is_hit(
-            self.image, crop, self.content_size, terminal_sizes, self._sixel_options
+            self.image, crop, self.content_size, terminal_sizes, self._sixel_options, background
         ):
             logger.debug(f"using Sixel data from cache for crop region {crop}")
             sixel_data = self._cached_sixels.sixel_data
@@ -180,9 +184,9 @@ class _ImageSixelImpl(Widget, can_focus=False, inherit_css=False):
             image_data = self._scale_image(image_data, terminal_sizes)
             image_data = self._crop_image(image_data, crop, terminal_sizes)
 
-            sixel_data = image_to_sixels(image_data.pil_image, self._sixel_options)
+            sixel_data = image_to_sixels(image_data.pil_image, self._sixel_options, background=background)
             self._cached_sixels = _CachedSixels(
-                self.image, crop, self.content_size, terminal_sizes, self._sixel_options, sixel_data
+                self.image, crop, self.content_size, terminal_sizes, self._sixel_options, background, sixel_data
             )
 
         sixel_segments = self._get_sixel_segments(sixel_data)
@@ -207,6 +211,10 @@ class _ImageSixelImpl(Widget, can_focus=False, inherit_css=False):
         crop_pixels_bottom = crop.bottom * terminal_sizes.height
 
         return image.cropped(crop_pixels_left, crop_pixels_top, crop_pixels_right, crop_pixels_bottom)
+
+    def _get_background_rgba(self) -> BackgroundColor:
+        _, color = self.background_colors
+        return (color.r, color.g, color.b, color.a)
 
     def _get_sixel_segments(self, sixel_data: str) -> Iterable[Segment]:
         visible_region = self.screen.find_widget(self).visible_region


### PR DESCRIPTION
Add support to display images with transparent elements.

Example:
<img width="952" height="1401" alt="image" src="https://github.com/user-attachments/assets/09553e77-2391-4818-8098-c3b1b32e98b6" />


Original image:
<img width="792" height="803" alt="image" src="https://github.com/user-attachments/assets/348372fe-d218-47a8-b494-bec8a838b20c" />
