### PR TITLE
fix: replace deprecated PIL getdata() with get_flattened_data()

### DIFF
--- a/textual_image/_pixeldata.py
+++ b/textual_image/_pixeldata.py
@@ -138,5 +138,5 @@ class PixelData:
         Returns:
             An `Iterator` over `Iterable`s of pixel values.
         """
-        data = self._image.getdata()
+        data = self._image.get_flattened_data()
         yield from grouped(data, self._image.width)

--- a/textual_image/_pixeldata.py
+++ b/textual_image/_pixeldata.py
@@ -122,11 +122,15 @@ class PixelData:
         self._image.save(image_buffer, format="png", compress_level=2)
         return b64encode(image_buffer.getvalue()).decode("ascii")
 
-    def __iter__(self) -> Iterator[Iterable[int | Tuple[int, ...]]]:
+    def __iter__(self) -> Iterator[Iterable[float | Tuple[int, ...]]]:
         """Iterate the pixel data.
 
         Returns an `Iterator` over rows of the image.
         The rows are `Iterable`s of pixel values.
+
+        Pixel values are scalar (`float`) for single-band modes — `int` at runtime
+        for integer modes like ``"L"`` or ``"P"``, true `float` for ``"F"`` — and
+        `tuple[int, ...]` for multi-band modes (e.g. ``"RGB"``, ``"RGBA"``).
 
         Example:
             Iterate the image data::
@@ -138,5 +142,7 @@ class PixelData:
         Returns:
             An `Iterator` over `Iterable`s of pixel values.
         """
-        data = self._image.getdata()
+        # PIL types `get_flattened_data()` as `tuple[tuple[int, ...], ...] | tuple[float, ...]`,
+        # which mypy cannot lift to `Iterable[float | tuple[int, ...]]` on its own.
+        data: Iterable[float | Tuple[int, ...]] = self._image.get_flattened_data()
         yield from grouped(data, self._image.width)


### PR DESCRIPTION
## Summary

- Pillow has deprecated `Image.getdata()`. This PR switches `textual_image/_pixeldata.py` to use the new `Image.get_flattened_data()` method, which is identical except that it returns a tuple of pixel values instead of an internal Pillow data type.
- With `getdata()` the grouped() resolved to `Iterable[Any]` so that passed mypy because `Any` is assignable to anything
- With `get_flattened_data()` whose type is `tuple[tuple[int, ...], ...] | tuple[float, ...]`  the grouped() resolves to `Iterable[object]`, because mypy is not able to infer that is really `Iterable[float|Tuple[int,...]]` so I needed to add add a cast and change the return type 



Closes #106 