### PR TITLE
ci: ensure lockfile integrity during automated releases

### DIFF
--- a/.github/actions/amend-version-sync/action.yml
+++ b/.github/actions/amend-version-sync/action.yml
@@ -1,0 +1,18 @@
+name: Amend release version sync
+description: Fold textual-image version bump in uv.lock into the release commit
+
+runs:
+  using: composite
+  steps:
+    - name: Amend current commit
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add uv.lock
+        if git diff --staged --quiet; then
+          echo "No lockfile changes to amend"
+          exit 0
+        fi
+        git commit --amend --no-edit
+        git push --force-with-lease

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -9,6 +9,9 @@ runs:
       with:
         enable-cache: true
 
+    - name: Sync project versions
+      uses: ./.github/actions/sync-versions
+
     - name: Build
       shell: bash
       run: uv build

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -39,6 +39,9 @@ runs:
         python-version: ${{ inputs.python-version }}
         enable-cache: true
 
+    - name: Sync project versions
+      uses: ./.github/actions/sync-versions
+
     - name: Sync quality tools
       if: inputs.run-format == 'true' || inputs.run-lint == 'true' || inputs.run-spell-check == 'true'
       shell: bash

--- a/.github/actions/sync-versions/action.yml
+++ b/.github/actions/sync-versions/action.yml
@@ -1,0 +1,9 @@
+name: Sync project versions
+description: Bump textual-image version in uv.lock to match [project].version
+
+runs:
+  using: composite
+  steps:
+    - name: Sync versions and lockfile
+      shell: bash
+      run: python3 scripts/sync_project_versions.py

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,35 @@
+name: Release Please sync
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-please-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  amend-version-sync:
+    name: Amend uv.lock into release commit
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+
+    - name: Sync project versions
+      uses: ./.github/actions/sync-versions
+
+    - name: Amend version sync
+      uses: ./.github/actions/amend-version-sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,6 @@ dev = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.12.0"
-tag_format = "v$version"
 
 [tool.hatch.build.targets.wheel]
 packages = ["textual_image"]
@@ -92,6 +90,7 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]
+"scripts/**" = ["T201"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/scripts/sync_project_versions.py
+++ b/scripts/sync_project_versions.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Set the textual-image package version in uv.lock to match [project].version."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path("pyproject.toml")
+UV_LOCK = Path("uv.lock")
+PACKAGE_VERSION_RE = re.compile(
+    r'\[\[package\]\]\nname = "textual-image"\nversion = "([^"]+)"',
+)
+PACKAGE_VERSION_SUB = re.compile(
+    r'(\[\[package\]\]\nname = "textual-image"\nversion = ")[^"]+(")',
+)
+
+
+def main() -> int:
+    project_version = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["project"]["version"]
+
+    lock_text = UV_LOCK.read_text(encoding="utf-8")
+    match = PACKAGE_VERSION_RE.search(lock_text)
+    if match is None:
+        print("Could not find textual-image package in uv.lock", file=sys.stderr)
+        return 1
+
+    if match.group(1) == project_version:
+        print(f"uv.lock already lists textual-image {project_version}")
+    else:
+        lock_text = PACKAGE_VERSION_SUB.sub(rf"\g<1>{project_version}\g<2>", lock_text, count=1)
+        UV_LOCK.write_text(lock_text, encoding="utf-8")
+        print(f"Set textual-image version in uv.lock to {project_version}")
+
+    check = subprocess.run(["uv", "lock", "--check"], capture_output=True, text=True)
+    if check.returncode != 0:
+        print(check.stdout, file=sys.stderr)
+        print(check.stderr, file=sys.stderr)
+        print(
+            "uv.lock is out of sync beyond the package version; run `uv lock` locally",
+            file=sys.stderr,
+        )
+        return check.returncode
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -952,7 +952,7 @@ wheels = [
 
 [[package]]
 name = "textual-image"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
To guarantee reproducible builds and consistent environments, uv.lock must remain synchronized with any version bumps in pyproject.toml. This change automates that synchronization within the CI pipeline to prevent the risk of publishing packages with stale dependency locks.