### PR TITLE
fix(build): include Python modules in hatchling wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,6 @@ name = "cz_conventional_commits"
 [tool.hatch.build.targets.wheel]
 packages = ["textual_image"]
 
-[tool.hatch.build]
-include = [
-    "textual_image/gracehopper.jpg",
-    "textual_image/py.typed",
-]
-
 [tool.ruff]
 lint.select = ["A", "ANN", "C", "E", "F", "FIX", "I", "N", "PTH", "T", "TC", "Q"]
 lint.ignore = ["A002"]


### PR DESCRIPTION
Remove the [tool.hatch.build] include allowlist that restricted the wheel to gracehopper.jpg and py.typed. Hatchling treats include as an exclusive filter, so packages = ["textual_image"] was ignored and no .py files were shipped.